### PR TITLE
More autofixes for `no-unused-vars`

### DIFF
--- a/packages/autofix/lib/rules/no-unused-vars.js
+++ b/packages/autofix/lib/rules/no-unused-vars.js
@@ -117,7 +117,7 @@ module.exports = ruleComposer.mapReports(
 
                             const i = node.range[0];
 
-                            return fixer.replaceTextRange([i, i], prefix);
+                            return fixer.insertTextBefore(node, prefix);
                         }
                         case "after-used": {
                             const comma = sourceCode.getTokenBefore(node, commaFilter);

--- a/packages/autofix/lib/rules/no-unused-vars.js
+++ b/packages/autofix/lib/rules/no-unused-vars.js
@@ -12,9 +12,82 @@ const rule = utils.getFixableRule("no-unused-vars", false);
 
 const commaFilter = { filter: token => token.value === "," };
 
+/**
+ * Process the raw options into a config object.
+ *
+ * This function is directly copied from eslint source code.
+ *
+ * @param {Object} options Options from context
+ * @returns {Object} config The rule config
+ */
+function getConfig(options) {
+    const firstOption = options[0];
+    const config = {
+        vars: "all",
+        args: "after-used",
+        ignoreRestSiblings: false,
+        caughtErrors: "none"
+    };
+
+    if (firstOption) {
+        if (typeof firstOption === "string") {
+            config.vars = firstOption;
+        } else {
+            config.vars = firstOption.vars || config.vars;
+            config.args = firstOption.args || config.args;
+            config.ignoreRestSiblings = firstOption.ignoreRestSiblings || config.ignoreRestSiblings;
+            config.caughtErrors = firstOption.caughtErrors || config.caughtErrors;
+
+            if (firstOption.varsIgnorePattern) {
+                config.varsIgnorePattern = new RegExp(firstOption.varsIgnorePattern, "u");
+            }
+
+            if (firstOption.argsIgnorePattern) {
+                config.argsIgnorePattern = new RegExp(firstOption.argsIgnorePattern, "u");
+            }
+
+            if (firstOption.caughtErrorsIgnorePattern) {
+                config.caughtErrorsIgnorePattern = new RegExp(firstOption.caughtErrorsIgnorePattern, "u");
+            }
+        }
+    }
+
+    return config;
+}
+
+/**
+ * getIgnoredArgPrefix extracts the prefix from the regex.
+ *
+ * Commonly argsIgnorePattern will be a regex that matches a prefix to a
+ * variable name. The prefix is a way to indicate the arguments is explicitly
+ * unused.
+ *
+ * @param {Object} config rule config
+ * @returns {string | null} the prefix, if it exists
+ */
+function getIgnoredArgPrefix(config) {
+    const { argsIgnorePattern } = config;
+
+    if (!argsIgnorePattern) {
+        return null;
+    }
+
+    const m = argsIgnorePattern.toString().match(/^\/\^(\w+)\/\w?$/);
+
+    if (!m) {
+        return null;
+    }
+
+    return m[1];
+}
+
 module.exports = ruleComposer.mapReports(
     rule,
-    (problem, { sourceCode }) => {
+    (problem, context) => {
+        const { sourceCode } = context;
+
+        const config = getConfig(context.options);
+
         problem.fix = fixer => {
             const { node } = problem;
             const { parent } = node;
@@ -25,6 +98,36 @@ module.exports = ruleComposer.mapReports(
             const grand = parent.parent;
 
             switch (parent.type) {
+                case "FunctionExpression":
+                case "FunctionDeclaration":
+                case "ArrowFunctionExpression":
+
+                    // Don't autofix unused functions, it's likely a mistake
+                    if (parent.id === node) {
+                        return null;
+                    }
+
+                    switch (config.args) {
+                        case "all": {
+                            const prefix = getIgnoredArgPrefix(config);
+
+                            if (prefix === null) {
+                                return null;
+                            }
+
+                            const i = node.range[0];
+
+                            return fixer.replaceTextRange([i, i], prefix);
+                        }
+                        case "after-used": {
+                            const comma = sourceCode.getTokenBefore(node, commaFilter);
+
+                            return [fixer.remove(comma), fixer.remove(node)];
+                        }
+                        default:
+                            throw new Error("Invalid rule config value for 'args'");
+                    }
+
                 case "ImportSpecifier":
                 case "ImportDefaultSpecifier":
                 case "ImportNamespaceSpecifier":

--- a/packages/autofix/lib/rules/no-unused-vars.js
+++ b/packages/autofix/lib/rules/no-unused-vars.js
@@ -115,8 +115,6 @@ module.exports = ruleComposer.mapReports(
                                 return null;
                             }
 
-                            const i = node.range[0];
-
                             return fixer.insertTextBefore(node, prefix);
                         }
                         case "after-used": {

--- a/packages/autofix/tests/lib/rules/no-unused-vars.js
+++ b/packages/autofix/tests/lib/rules/no-unused-vars.js
@@ -193,6 +193,68 @@ ruleTester.run("no-unused-vars", rule, {
             errors: [{ type: "Identifier" }, { type: "Identifier" }]
         },
         {
+            code: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
+            output: "function foo(a, b ){console.log(b);}; foo(1, 2, 3);",
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { type: "Identifier" }
+            ],
+            options: [{
+                args: "after-used",
+                argsIgnorePattern: "^_"
+            }]
+        },
+        {
+            code: "const foo = function(a, b, c) {console.log(b);}; foo(1, 2, 3);",
+            output: "const foo = function(a, b ) {console.log(b);}; foo(1, 2, 3);",
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { type: "Identifier" }
+            ],
+            options: [{
+                args: "after-used",
+                argsIgnorePattern: "^_"
+            }]
+        },
+        {
+            code: "const foo = (a, b, c) => {console.log(b);}; foo(1, 2, 3);",
+            output: "const foo = (a, b ) => {console.log(b);}; foo(1, 2, 3);",
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { type: "Identifier" }
+            ],
+            options: [{
+                args: "after-used",
+                argsIgnorePattern: "^_"
+            }]
+        },
+        {
+            code: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
+            output: "function foo(_a, b, _c){console.log(b);}; foo(1, 2, 3);",
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { type: "Identifier" },
+                { type: "Identifier" }
+            ],
+            options: [{
+                args: "all",
+                argsIgnorePattern: "^_"
+            }]
+        },
+        {
+            code: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
+            output: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { type: "Identifier" },
+                { type: "Identifier" }
+            ],
+            options: [{
+                args: "all",
+                argsIgnorePattern: "_$"
+            }]
+        },
+        {
             code: "let {a} = b",
             output: "let {} = b",
             parserOptions: { ecmaVersion: 6 },

--- a/packages/autofix/tests/lib/rules/no-unused-vars.js
+++ b/packages/autofix/tests/lib/rules/no-unused-vars.js
@@ -243,7 +243,7 @@ ruleTester.run("no-unused-vars", rule, {
         },
         {
             code: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
-            output: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
+            output: null,
             parserOptions: { ecmaVersion: 2018 },
             errors: [
                 { type: "Identifier" },
@@ -252,6 +252,18 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{
                 args: "all",
                 argsIgnorePattern: "_$"
+            }]
+        },
+        {
+            code: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
+            output: null,
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+                { type: "Identifier" },
+                { type: "Identifier" }
+            ],
+            options: [{
+                args: "all"
             }]
         },
         {


### PR DESCRIPTION
This PR adds two new ways a `no-unused-vars` problem can be autofixed:

1. With `args: "after-used"`, unused arguments to functions will be
   deleted.
2. With `args: "all"` and an `argsIgnorePattern` that is a simple
   prefix, the prefix will be added to unused function  arguments.

The second one is especially useful for me and I used to to autofix
~260 problems at Flexport. We use an underscore to mark an argument as
unused. Here's a simple example:

```diff
-  onUpdateError = (response, status, error) => {
+  onUpdateError = (_response, _status, error) => {
```