### PR TITLE
no-unused-vars 1 arg arrow fns

### DIFF
--- a/packages/autofix/lib/rules/no-unused-vars.js
+++ b/packages/autofix/lib/rules/no-unused-vars.js
@@ -116,6 +116,21 @@ module.exports = ruleComposer.mapReports(
                             return fixer.insertTextBefore(node, prefix);
                         }
                         case "after-used": {
+                            const tokenBefore = sourceCode.getTokenBefore(node)
+                            const tokenAfter = sourceCode.getTokenAfter(node)
+
+                            if (
+                              parent.params.length === 1 &&
+                              !(tokenBefore && tokenBefore.value === '(') &&
+                              !(tokenAfter && tokenAfter.value === ')')
+                            ) {
+                                return [
+                                  fixer.insertTextBefore(node, '('),
+                                  fixer.insertTextAfter(node, ')'),
+                                  fixer.remove(node)
+                                ]
+                            }
+
                             const comma = sourceCode.getTokenBefore(node, commaFilter);
 
                             if (comma && comma.range && grand.range && comma.range[0] >= grand.range[0]) {
@@ -126,7 +141,6 @@ module.exports = ruleComposer.mapReports(
                             if (commaAfter && commaAfter.range && grand.range && commaAfter.range[1] <= grand.range[1]) {
                                 return [fixer.remove(node), fixer.remove(commaAfter)];
                             }
-
 
                             return [fixer.remove(node)];
                         }

--- a/packages/autofix/tests/lib/rules/no-unused-vars.js
+++ b/packages/autofix/tests/lib/rules/no-unused-vars.js
@@ -238,6 +238,30 @@ ruleTester.run("no-unused-vars", rule, {
             }]
         },
         {
+            code: "const foo = (a) => {}; foo();",
+            output: "const foo = () => {}; foo();",
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+              { type: "Identifier" }
+            ],
+            options: [{
+                args: "after-used",
+                argsIgnorePattern: "^_",
+            }]
+        },
+        {
+            code: "const foo = a => {}; foo();",
+            output: "const foo = () => {}; foo();",
+            parserOptions: { ecmaVersion: 2018 },
+            errors: [
+              { type: "Identifier" }
+            ],
+            options: [{
+                args: "after-used",
+                argsIgnorePattern: "^_",
+            }]
+        },
+        {
             code: "function foo(a, b, c){console.log(b);}; foo(1, 2, 3);",
             output: "function foo(_a, b, _c){console.log(b);}; foo(1, 2, 3);",
             parserOptions: { ecmaVersion: 2018 },


### PR DESCRIPTION
Arrow functions with no brackets and just one argument were being fixed incorrectly

From:
```tsx
const Foo = props => <div>Foo</div>
```
To:
```tsx
const Foo =  => <div>Foo</div>
```

This PR makes it into:
```tsx
const Foo = () => <div>Foo</div>
```