### PR TITLE
feat: add `no-new-native-nonconstructor`

### DIFF
--- a/packages/autofix/lib/rules/no-new-native-nonconstructor.js
+++ b/packages/autofix/lib/rules/no-new-native-nonconstructor.js
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview Add fixer to rule no-new-native-nonconstructor.
+ * @author SukkaW <github@skk.moe>
+ */
+"use strict";
+
+const ruleComposer = require("eslint-rule-composer");
+const utils = require("../utils");
+
+const rule = utils.getFixableRule("no-new-native-nonconstructor", true);
+
+module.exports = ruleComposer.mapReports(
+    rule,
+    problem => {
+        problem.fix = fixer => {
+            const parent = problem.node.parent;
+
+            return fixer.removeRange([parent.range[0], parent.range[0] + 4]);
+        };
+        return problem;
+    }
+);

--- a/packages/autofix/tests/lib/rules/no-new-native-nonconstructor.js
+++ b/packages/autofix/tests/lib/rules/no-new-native-nonconstructor.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Tests for rule no-new-native-nonconstructor
+ * @author SukkaW <github@skk.moe>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/no-new-native-nonconstructor.js");
+const RuleTester = require("../../rule-tester.js").RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("no-new-native-nonconstructor", rule, {
+    valid: [
+        "Symbol('a')",
+        "BigInt(42)"
+    ],
+    invalid: [
+        {
+            code: "new Symbol('a')",
+            output: "Symbol('a')",
+            errors: 1
+        },
+        {
+            code: "new BigInt(0x721)",
+            output: "BigInt(0x721)",
+            errors: 1
+        }
+    ]
+});


### PR DESCRIPTION
`no-new-symbol` has been deprecated since ESLint 9.0.0 and was replaced by `no-new-native-nonconstructor`. The PR adds autofix support for `no-new-native-nonconstructor`.
