### PR TITLE
refactor: drop lodash

### DIFF
--- a/packages/autofix/package.json
+++ b/packages/autofix/package.json
@@ -19,7 +19,6 @@
     "eslint-rule-composer": "^0.3.0",
     "espree": "^9.0.0",
     "esutils": "^2.0.2",
-    "lodash": "^4.17.20",
     "string-similarity": "^4.0.3"
   },
   "devDependencies": {

--- a/packages/web/lib/utils.js
+++ b/packages/web/lib/utils.js
@@ -7,7 +7,7 @@
 
 const esutils = require("esutils");
 const espree = require("espree");
-const lodash = require("lodash");
+const escapeStringRegexp = require("escape-string-regexp");
 
 const breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/u;
 const lineBreakPattern = /\r\n|[\r\n\u2028\u2029]/u;
@@ -1312,7 +1312,7 @@ module.exports = {
      * @returns {SourceLocation} The `loc` object.
      */
     getNameLocationInGlobalDirectiveComment(sourceCode, comment, name) {
-        const namePattern = new RegExp(`[\\s,]${lodash.escapeRegExp(name)}(?:$|[\\s,:])`, "gu");
+        const namePattern = new RegExp(`[\\s,]${escapeStringRegexp(name)}(?:$|[\\s,:])`, "gu");
 
         // To ignore the first text "global".
         namePattern.lastIndex = comment.value.indexOf("global") + 6;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "espree": "^7.3.1",
     "esutils": "^2.0.3",
-    "lodash": "^4.17.20"
+    "escape-string-regexp": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": ">4"


### PR DESCRIPTION
`eslint-plugin-autofix` doesn't use lodash at all while `eslint-plugin-web` only uses `lodash.escapeRegexp` (which can be replaced w/ a single package without whole megabytes of lodash).

The PR drops lodash.